### PR TITLE
Changing analysis name to allow development module installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,8 @@ Maintainer: Dustin Fife <fife.dustin@gmail.com>
 Description: Graphically explore the dependencies between variables
 License: GPL (>= 2)
 Imports: flexplot, jaspBase, jaspGraphs, jaspDescriptives
-Remotes: 
-	dustinfife/flexplot,
-	jasp-stats/jaspGraphs,
-        jasp-stats/jaspBase,
-        jasp-stats/jaspDescriptives
+Remotes:
+  dustinfife/flexplot,
+  jasp-stats/jaspGraphs,
+  jasp-stats/jaspBase,
+  jasp-stats/jaspDescriptives

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -4,7 +4,7 @@ import JASP.Module 	1.0
 Description
 {
 	title :         qsTr("Visual Modeling")
-	name :          "Visual Modeling"
+	name :          "jaspVisualModeling"
 	description:    qsTr("Graphically explore the dependencies between variables")
 	version			: "0.19.0"
 	author:         "Dustin Fife"


### PR DESCRIPTION
The analysis name defined in *Description.qml* broke the development module installation. The dev module installer seems to use the analysis name from the QML description to define the path searched for module assets. The new name allows this module to be installed as a development module.

This module has no unit tests, so I can only hope that this change doesn't break anything else.